### PR TITLE
remove php input to postrequest

### DIFF
--- a/src/vclaim/BridgingBpjs.php
+++ b/src/vclaim/BridgingBpjs.php
@@ -38,7 +38,6 @@ class BridgingBpjs
 
 	public function postRequest($endpoint, $data)
     {
-        $data = file_get_contents("php://input");
         try {
             $url = $this->setServiceApi() . $endpoint;
             $response = $this->client->post($url, ['headers' => $this->setHeaders(), 'body' => $data]);


### PR DESCRIPTION
Hello sir,

Saya menemukan bug ketika postRequest menggunakan bpjs v2.
ketika di line 41 ada file_get_contents("php://input"); itu response null. karena bpjs hanya menerima json bukan string.

bug:
![image](https://user-images.githubusercontent.com/13324085/147804411-3ca7a5d1-50c3-4444-bfaa-c2d9040823cf.png)

untuk memperbaikinya saya hapus file_get_contents("php://input"); 

Signed-off-by: ferifahrul7 <ferifahrul7@gmail.com>